### PR TITLE
Handle BadRequestError and JWT errors in UserController

### DIFF
--- a/app/backend/src/controllers/UserController.ts
+++ b/app/backend/src/controllers/UserController.ts
@@ -1,9 +1,12 @@
-import { Request, Response } from "express";
-import { StatusCodes } from "http-status-codes";
+import { Request, Response } from 'express';
+import { StatusCodes } from 'http-status-codes';
 import UserService from '../services/UserService';
 import UnauthorizedError from '../utils/errors/UnauthorizedError';
 import UnprocessableEntityError from '../utils/errors/UnprocessableEntityError';
 import ValidationError from '../utils/errors/ValidationError';
+import NotFoundError from '../utils/errors/NotFoundError';
+import BadRequestError from '../utils/errors/BadRequestError';
+import { JsonWebTokenError } from 'jsonwebtoken';
 
 class UserController {
   private _service: UserService;
@@ -20,21 +23,41 @@ class UserController {
     try {
       const userData = await this._service.login(req.body);
       res.status(StatusCodes.OK).json(userData);
+      return;
     } catch (error: any) {
       console.error('Erreur login:', error);
 
-      if (
-        error instanceof UnprocessableEntityError ||
-        error instanceof ValidationError
-      ) {
+      if (error instanceof UnprocessableEntityError) {
+        res
+          .status(StatusCodes.UNPROCESSABLE_ENTITY)
+          .json({ message: error.message });
+        return;
+      }
+
+      if (error instanceof BadRequestError) {
         res.status(StatusCodes.BAD_REQUEST).json({ message: error.message });
+        return;
+      }
+
+      if (error instanceof ValidationError) {
+        res.status(StatusCodes.BAD_REQUEST).json({ message: error.message });
+        return;
       }
 
       if (error instanceof UnauthorizedError) {
         res.status(StatusCodes.UNAUTHORIZED).json({ message: error.message });
+        return;
       }
 
-      res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ error: 'Internal server error' });
+      if (error instanceof NotFoundError) {
+        res.status(StatusCodes.NOT_FOUND).json({ message: error.message });
+        return;
+      }
+
+      res
+        .status(StatusCodes.INTERNAL_SERVER_ERROR)
+        .json({ message: 'Erro interno do servidor.' });
+      return;
     }
   }
 
@@ -42,21 +65,41 @@ class UserController {
     try {
       await this._service.register(req.body);
       res.status(StatusCodes.CREATED).json({ message: 'Usuário registrado com sucesso.' });
+      return;
     } catch (error: any) {
       console.error('Erreur register:', error);
 
-      if (
-        error instanceof UnprocessableEntityError ||
-        error instanceof ValidationError
-      ) {
+      if (error instanceof UnprocessableEntityError) {
+        res
+          .status(StatusCodes.UNPROCESSABLE_ENTITY)
+          .json({ message: error.message });
+        return;
+      }
+
+      if (error instanceof BadRequestError) {
         res.status(StatusCodes.BAD_REQUEST).json({ message: error.message });
+        return;
+      }
+
+      if (error instanceof ValidationError) {
+        res.status(StatusCodes.BAD_REQUEST).json({ message: error.message });
+        return;
       }
 
       if (error instanceof UnauthorizedError) {
         res.status(StatusCodes.UNAUTHORIZED).json({ message: error.message });
+        return;
       }
 
-      res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ error: 'Internal server error' });
+      if (error instanceof NotFoundError) {
+        res.status(StatusCodes.NOT_FOUND).json({ message: error.message });
+        return;
+      }
+
+      res
+        .status(StatusCodes.INTERNAL_SERVER_ERROR)
+        .json({ message: 'Erro interno do servidor.' });
+      return;
     }
   }
 
@@ -64,9 +107,48 @@ class UserController {
     try {
       const balance = await this._service.getBalance(req.headers.authorization);
       res.status(StatusCodes.OK).json({ balance });
+      return;
     } catch (error: any) {
       console.error('Erreur getBalance:', error);
-      res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ error: 'Internal server error' });
+
+      if (error instanceof UnprocessableEntityError) {
+        res
+          .status(StatusCodes.UNPROCESSABLE_ENTITY)
+          .json({ message: error.message });
+        return;
+      }
+
+      if (error instanceof ValidationError) {
+        res.status(StatusCodes.BAD_REQUEST).json({ message: error.message });
+        return;
+      }
+
+      if (error instanceof BadRequestError) {
+        res.status(StatusCodes.BAD_REQUEST).json({ message: error.message });
+        return;
+      }
+
+      if (error instanceof UnauthorizedError) {
+        res.status(StatusCodes.UNAUTHORIZED).json({ message: error.message });
+        return;
+      }
+
+      if (error instanceof JsonWebTokenError) {
+        res
+          .status(StatusCodes.UNAUTHORIZED)
+          .json({ message: 'Token inválido ou expirado.' });
+        return;
+      }
+
+      if (error instanceof NotFoundError) {
+        res.status(StatusCodes.NOT_FOUND).json({ message: error.message });
+        return;
+      }
+
+      res
+        .status(StatusCodes.INTERNAL_SERVER_ERROR)
+        .json({ message: 'Erro interno do servidor.' });
+      return;
     }
   }
 }


### PR DESCRIPTION
## Summary
- map `BadRequestError` to `StatusCodes.BAD_REQUEST`
- handle `JsonWebTokenError` in `getBalance`
- ensure single return path for each branch

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844245ef3408330a79fbc93b54a33cd