### PR TITLE
Fix Jenkins test step for frontend

### DIFF
--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "echo \"No frontend tests configured\""
   },
   "dependencies": {
     "@types/node": "18.11.9",


### PR DESCRIPTION
## Summary
- add placeholder `npm test` script for the frontend so Jenkins pipelines won't fail

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684429921cf4833085a8e71f1e2b4cb3